### PR TITLE
Resolved Parse issue with nullable properties

### DIFF
--- a/src/JsonTypeDefinition/JsonTypeDefinitionParser.cs
+++ b/src/JsonTypeDefinition/JsonTypeDefinitionParser.cs
@@ -121,6 +121,8 @@ namespace JsonTypeDefinition
 
         private static JsonTypeDefinitionSchema GetTypeSchema(Type type)
         {
+            //to map nullables to JTD types, get underlying
+            type = Nullable.GetUnderlyingType(type) ?? type;
             return new() { Type = typeMapping[type] };
         }
 


### PR DESCRIPTION
Tried to integrate your solution, but an object with nullable properties failed to work with `JsonTypeDefinitionParser.Parse`. Found that while a nullable check was done elsewhere, it needs to be incorporated in this function.

Thanks! Hoping this will work.